### PR TITLE
Can Driver

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibLPC40xxConan(ConanFile):
     name = "liblpc40xx"
-    version = "0.0.0"
+    version = "0.2.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/liblpc40xx"
@@ -40,6 +40,8 @@ class LibLPC40xxConan(ConanFile):
         }
 
     def requirements(self):
+        self.requires("libhal/0.1.4@")
+        self.requires("libxbitset/[x]@")
         self.requires("libarmcortex/[x]@")
         self.requires("ring-span-lite/0.6.0")
 

--- a/demos/adc/main.cpp
+++ b/demos/adc/main.cpp
@@ -31,8 +31,7 @@ int main()
   hal::cortex_m::system_control().initialize_floating_point_unit();
 
   static hal::cortex_m::dwt_counter counter(
-    hal::lpc40xx::internal::get_clock().get_frequency(
-      hal::lpc40xx::peripheral::cpu));
+    hal::lpc40xx::get_clock().get_frequency(hal::lpc40xx::peripheral::cpu));
 
   constexpr hal::serial::settings new_settings{ .baud_rate = 38400 };
   auto& uart0 = hal::lpc40xx::get_uart<0>(new_settings);

--- a/demos/blinker/main.cpp
+++ b/demos/blinker/main.cpp
@@ -22,7 +22,7 @@ int main()
   hal::cortex_m::initialize_data_section();
   hal::cortex_m::system_control().initialize_floating_point_unit();
 
-  auto& clock = hal::lpc40xx::internal::clock::get();
+  auto& clock = hal::lpc40xx::clock::get();
   hal::cortex_m::dwt_counter steady_clock(
     clock.get_frequency(hal::lpc40xx::peripheral::cpu));
 

--- a/demos/can/CMakeLists.txt
+++ b/demos/can/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15)
+
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/../cmake/toolchain.cmake)
+
+project(main VERSION 0.0.1 LANGUAGES CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+find_package(liblpc40xx REQUIRED CONFIG)
+
+set(LINKER_SCRIPT_PATHS ${CMAKE_SOURCE_DIR}/../../linker)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC .)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_options(${PROJECT_NAME} PRIVATE ${CORTEX_M4_FLAGS})
+target_link_options(${PROJECT_NAME} PRIVATE ${CORTEX_M4_FLAGS}
+    -L${LINKER_SCRIPT_PATHS} -T${LINKER_SCRIPT_PATHS}/lpc4078.ld
+    -Wl,-Map=${PROJECT_NAME}.map,--cref -Wl,--gc-sections
+    -Wl,--print-memory-usage)
+target_link_libraries(${PROJECT_NAME} PRIVATE liblpc40xx::liblpc40xx)
+arm_post_build(${PROJECT_NAME})

--- a/demos/can/conanfile.txt
+++ b/demos/can/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+liblpc40xx/[x]
+
+[generators]
+CMakeToolchain
+CMakeDeps
+VirtualRunEnv

--- a/demos/can/libhal.tweaks.hpp
+++ b/demos/can/libhal.tweaks.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string_view>
+
+namespace hal::config {
+constexpr std::string_view platform = "lpc40xx";
+}  // namespace hal::config

--- a/demos/can/main.cpp
+++ b/demos/can/main.cpp
@@ -1,0 +1,102 @@
+#define BOOST_LEAF_EMBEDDED
+#define BOOST_LEAF_NO_THREADS
+
+#include <array>
+#include <string_view>
+
+#include <libarmcortex/dwt_counter.hpp>
+#include <libarmcortex/startup.hpp>
+#include <libarmcortex/system_control.hpp>
+#include <libhal/serial/util.hpp>
+#include <libhal/steady_clock/util.hpp>
+#include <liblpc40xx/can.hpp>
+#include <liblpc40xx/uart.hpp>
+
+using namespace hal::literals;
+
+// Do not change this, this is the max speed of the internal PLL
+static constexpr auto max_speed = 120.0_MHz;
+// Change the CAN baudrate here.
+static constexpr auto baudrate = 100.0_kHz;
+// If "baudrate" is above 100.0_kHz, then an external crystal must be used for
+// clock rate accuracy.
+static constexpr auto external_crystal_frequency = 12.0_MHz;
+
+int main()
+{
+  using namespace std::chrono_literals;
+
+  hal::cortex_m::initialize_data_section();
+  hal::cortex_m::system_control().initialize_floating_point_unit();
+
+  auto& clock = hal::lpc40xx::clock::get();
+
+  // Set CPU & peripheral clock speed to 120MHz
+  auto& config = clock.get_clock_config();
+
+  config.oscillator_frequency = external_crystal_frequency;
+  config.use_external_oscillator = true;
+  config.cpu.use_pll0 = true;
+  config.peripheral_divider = 1;
+  config.pll[0].enabled = true;
+  config.pll[0].multiply =
+    static_cast<uint8_t>(max_speed / external_crystal_frequency);
+
+  clock.reconfigure_clocks();
+
+  hal::cortex_m::dwt_counter counter(
+    clock.get_frequency(hal::lpc40xx::peripheral::cpu));
+  auto& uart0 = hal::lpc40xx::uart::get<0>({ .baud_rate = 38400.0f });
+  auto& can1 =
+    hal::lpc40xx::can::get<1>(hal::can::settings{ .baud_rate = 1.0_MHz })
+      .value();
+  auto& can2 =
+    hal::lpc40xx::can::get<2>(hal::can::settings{ .baud_rate = 1.0_MHz })
+      .value();
+
+  std::array<hal::byte, 1024> buffer;
+
+  (void)can1.on_receive([&uart0,
+                         &buffer](const hal::can::message_t& p_message) {
+    int count = snprintf(reinterpret_cast<char*>(buffer.data()),
+                         buffer.size(),
+                         "Received Message from ID: 0x%lX, length: %u \n"
+                         "payload = [ 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, "
+                         "0x%02X, 0x%02X, 0x%02X ]\n",
+                         p_message.id,
+                         p_message.length,
+                         p_message.payload[0],
+                         p_message.payload[1],
+                         p_message.payload[2],
+                         p_message.payload[3],
+                         p_message.payload[4],
+                         p_message.payload[5],
+                         p_message.payload[6],
+                         p_message.payload[7]);
+
+    (void)hal::write(uart0, buffer);
+  });
+
+  std::string_view sent_message = "SENDING!!!\n";
+
+  while (true) {
+    hal::can::message_t my_message{
+      .id = 0x0111,
+      .payload = { 0xAA, 0xBB, 0xCC, 0xDD, 0xDE, 0xAD, 0xBE, 0xEF },
+      .length = 8,
+      .is_remote_request = false,
+    };
+    // (void)hal::write(uart0, sent_message);
+    (void)can2.send(my_message);
+    (void)hal::delay(counter, 1s);
+  }
+
+  return 0;
+}
+
+namespace boost {
+void throw_exception(std::exception const& e)
+{
+  std::abort();
+}
+}  // namespace boost

--- a/demos/cmake/toolchain.cmake
+++ b/demos/cmake/toolchain.cmake
@@ -11,9 +11,13 @@ set(CMAKE_SYSTEM_PROCESSOR ARM)
 # ------------------------------------------------------------------------------
 set(TOOLCHAIN arm-none-eabi)
 
-if(NOT DEFINED ${CMAKE_BUILD_TYPE})
-    set(CMAKE_BUILD_TYPE "Release")
-endif(NOT DEFINED ${CMAKE_BUILD_TYPE})
+message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug")
+endif(NOT DEFINED CMAKE_BUILD_TYPE)
+
+message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
 # Set system depended extensions
 if(WIN32)

--- a/demos/gpio/main.cpp
+++ b/demos/gpio/main.cpp
@@ -16,8 +16,7 @@ int main()
   hal::cortex_m::system_control().initialize_floating_point_unit();
 
   hal::cortex_m::dwt_counter clock(
-    hal::lpc40xx::internal::clock::get().get_frequency(
-      hal::lpc40xx::peripheral::cpu));
+    hal::lpc40xx::clock::get().get_frequency(hal::lpc40xx::peripheral::cpu));
 
   auto& button = hal::lpc40xx::input_pin::get<0, 29>();
   auto& led = hal::lpc40xx::output_pin::get<1, 18>();

--- a/demos/uart/main.cpp
+++ b/demos/uart/main.cpp
@@ -16,7 +16,7 @@ int main()
   hal::cortex_m::initialize_data_section();
   hal::cortex_m::system_control().initialize_floating_point_unit();
 
-  auto& clock = hal::lpc40xx::internal::clock::get();
+  auto& clock = hal::lpc40xx::clock::get();
   hal::cortex_m::dwt_counter counter(
     clock.get_frequency(hal::lpc40xx::peripheral::cpu));
   auto& uart0 = hal::lpc40xx::uart::get<0>({ .baud_rate = 38400.0f });

--- a/include/liblpc40xx/adc.hpp
+++ b/include/liblpc40xx/adc.hpp
@@ -257,7 +257,7 @@ private:
       return hal::new_error();
     }
 
-    internal::power(peripheral::adc).on();
+    power(peripheral::adc).on();
 
     // For proper operation, analog pins must be set to floating.
     p_channel.pin.function(p_channel.pin_function)
@@ -265,8 +265,7 @@ private:
       .open_drain(false)
       .analog(true);
 
-    const auto clock_frequency =
-      internal::clock::get().get_frequency(peripheral::adc);
+    const auto clock_frequency = clock::get().get_frequency(peripheral::adc);
     const auto clock_divider = clock_frequency / p_channel.clock_rate;
     const auto clock_divider_int = static_cast<std::uint32_t>(clock_divider);
 

--- a/include/liblpc40xx/can.hpp
+++ b/include/liblpc40xx/can.hpp
@@ -3,11 +3,11 @@
 #include <string_view>
 
 #include <libarmcortex/interrupt.hpp>
-#include <libhal/can/can.hpp>
+#include <libhal/can/interface.hpp>
 #include <libhal/static_callable.hpp>
 #include <libxbitset/bitset.hpp>
 
-#include "internal/constants.hpp"
+#include "constants.hpp"
 #include "internal/pin.hpp"
 #include "system_controller.hpp"
 
@@ -215,7 +215,7 @@ public:
     static constexpr auto tx3_released = xstd::bitrange::from<18>();
   };
 
-  /// CANBUS modes
+  /// CAN BUS modes
   struct mode
   {
     /// Reset CAN Controller, allows configuration registers to be modified.
@@ -241,7 +241,7 @@ public:
     static constexpr auto test = xstd::bitrange::from<7>();
   };
 
-  /// CANBus frame bit masks for the TFM and RFM registers
+  /// CAN Bus frame bit masks for the TFM and RFM registers
   struct frame_info
   {
     /// The message priority bits (not used in this implementation)
@@ -268,7 +268,7 @@ public:
     accept_all_messages = 0x02,
   };
 
-  /// Contains all of the information for to control and configure a CANBUS bus
+  /// Contains all of the information for to control and configure a CAN BUS bus
   /// on the LPC40xx platform.
   struct port
   {
@@ -294,16 +294,16 @@ public:
     irq irq_number;
 
     /// Number of time quanta for sync bits - 1
-    unsigned sync_jump = 0;
+    std::uint8_t sync_jump = 0;
 
     /// Number of time quanta for tseg1 - 1
-    unsigned tseg1 = 6;
+    std::uint8_t tseg1 = 6;
 
     /// Number of time quanta for tseg2 - 1
-    unsigned tseg2 = 1;
+    std::uint8_t tseg2 = 1;
   };
 
-  /// Container for the LPC40xx CANBUS registers
+  /// Container for the LPC40xx CAN BUS registers
   struct lpc_message
   {
     /// TFI register contents
@@ -316,9 +316,64 @@ public:
     uint32_t data_b = 0;
   };
 
-  /// Pointer to the LPC CANBUS acceptance filter peripheral in memory
-  inline static auto* acceptance_filter =
-    reinterpret_cast<acceptance_filter_t*>(0x4003'C000);
+  /// Pointer to the LPC CAN BUS acceptance filter peripheral in memory
+  inline static auto& acceptance_filter()
+  {
+    if constexpr (hal::is_platform("lpc40")) {
+      return *reinterpret_cast<acceptance_filter_t*>(0x4003'C000);
+    } else if constexpr (hal::is_a_test()) {
+      static acceptance_filter_t dummy{};
+      return dummy;
+    }
+  }
+
+  template<int PortNumber>
+  static result<can&> get(can::settings p_settings = {})
+  {
+    compile_time_platform_check();
+    static_assert(PortNumber == 1 || PortNumber == 2,
+                  "\n\n"
+                  "LPC40xx Compile Time Error:\n"
+                  "    LPC40xx only supports CAN port numbers from 1 and 2. \n"
+                  "\n");
+
+    can::port port;
+
+    if constexpr (hal::is_platform("lpc40")) {
+      if constexpr (PortNumber == 1) {
+        port = can::port{
+          .td = internal::pin(0, 1),
+          .td_function_code = 1,
+          .rd = internal::pin(0, 0),
+          .rd_function_code = 1,
+          .reg = reinterpret_cast<can::reg_t*>(0x4004'4000),
+          .id = peripheral::can1,
+          .irq_number = irq::can,
+        };
+      } else if constexpr (PortNumber == 2) {
+        port = can::port{
+          .td = internal::pin(2, 8),
+          .td_function_code = 1,
+          .rd = internal::pin(2, 7),
+          .rd_function_code = 1,
+          .reg = reinterpret_cast<can::reg_t*>(0x4004'8000),
+          .id = peripheral::can2,
+          .irq_number = irq::can,
+        };
+      } else {
+        static_assert(hal::error::invalid_option<port>,
+                      "Support can ports for LPC40xx are can1 and can2.");
+      }
+    } else {
+      static std::array<can::reg_t, 2> registers{};
+      port.reg = &registers[PortNumber - 1];
+    }
+
+    HAL_CHECK(setup(port, p_settings));
+
+    static can can_channel(port);
+    return can_channel;
+  }
 
   /**
    * @brief Construct a new can object
@@ -330,14 +385,15 @@ public:
   {
   }
 
-  status driver_initialize() noexcept override;
-  status send(const message_t& p_message) noexcept override;
+  status driver_configure(const settings& p_settings) noexcept override;
+  status driver_send(const message_t& p_message) noexcept override;
+
   /**
    * @note This interrupt handler is used by both CAN1 and CAN2. This should
    *     only be called for 1 can port to service both receive handlers.
    */
-  status attach_interrupt(std::function<void(const can::message_t&)>
-                            p_receive_handler) noexcept override;
+  status driver_on_receive([[maybe_unused]] std::function<can::handler>
+                             p_receive_handler) noexcept override;
 
   /**
    * @brief Get the port details object
@@ -358,13 +414,15 @@ public:
   }
 
 private:
-  message_t receive();
-  bool has_data();
   /**
-   * @brief Set the baud rate based on the can settings clock_rate.
+   * @brief Set the baud rate based on the can settings baud_rate.
    *
    */
-  void configure_baud_rate();
+  static status configure_baud_rate(const can::port& p_port,
+                                    const settings& p_settings) noexcept;
+  static status setup(const can::port& p_port, settings p_settings) noexcept;
+  message_t receive() noexcept;
+  bool has_data() noexcept;
   /**
    * @brief Convert can message into LPC40xx can bus register format.
    *
@@ -380,69 +438,85 @@ private:
   static void enable_acceptance_filter();
 
   port m_port;
-  std::function<void(const can::message_t&)> m_receive_handler;
+  std::function<can::handler> m_receive_handler;
 };
 
-template<int PortNumber>
-inline can& get_can()
+// TODO: this needs to return a bool if the baud rate cannot be achieved
+inline status can::configure_baud_rate(const can::port& p_port,
+                                       const settings& p_settings) noexcept
 {
-  can::port port;
+  using namespace hal::literals;
 
-  if constexpr (PortNumber == 1) {
-    port = can::port{
-      .td = internal::pin(0, 1),
-      .td_function_code = 1,
-      .rd = internal::pin(0, 0),
-      .rd_function_code = 1,
-      .reg = reinterpret_cast<can::reg_t*>(0x4004'4000),
-      .id = peripheral::can1,
-      .irq_number = irq::can,
-    };
-  } else if constexpr (PortNumber == 2) {
-    port = can::port{
-      .td = internal::pin(2, 8),
-      .td_function_code = 1,
-      .rd = internal::pin(2, 7),
-      .rd_function_code = 1,
-      .reg = reinterpret_cast<can::reg_t*>(0x4004'8000),
-      .id = peripheral::can2,
-      .irq_number = irq::can,
-    };
-  } else {
-    static_assert(hal::invalid_option<port>,
-                  "Support can ports for LPC40xx are can1 and can2.");
+  if (p_settings.baud_rate > 100.0_kHz &&
+      !clock::get().get_clock_config().use_external_oscillator) {
+    return hal::new_error(std::errc::invalid_argument,
+                          error_t::requires_usage_of_external_oscillator);
   }
 
-  static can can_object(port);
-  return can_object;
-}
-}  // namespace hal::lpc40xx
+  const auto frequency = clock::get().get_frequency(p_port.id);
+  auto baud_rate_prescalar = p_settings.is_valid(frequency);
 
-namespace hal::lpc40xx {
-inline status can::driver_initialize()
+  if (!baud_rate_prescalar) {
+    return hal::new_error(std::errc::invalid_argument,
+                          error_t::baud_rate_impossible);
+  }
+
+  // Hold the results in RAM rather than altering the register directly
+  // multiple times.
+  xstd::bitmanip bus_timing(p_port.reg->BTR);
+
+  const auto sync_jump = p_settings.synchronization_jump_width - 1;
+  const auto tseg1 =
+    (p_settings.propagation_delay + p_settings.phase_segment1) - 1;
+  const auto tseg2 = p_settings.phase_segment2 - 1;
+  const auto final_baudrate_prescale = baud_rate_prescalar.value() - 1;
+
+  // Used to compensate for positive and negative edge phase errors. Defines
+  // how much the sample point can be shifted.
+  // These time segments determine the location of the "sample point".
+  bus_timing.insert<bus_timing::sync_jump_width>(sync_jump)
+    .insert<bus_timing::time_segment1>(tseg1)
+    .insert<bus_timing::time_segment2>(tseg2)
+    .insert<bus_timing::prescalar>(final_baudrate_prescale);
+
+  if (p_settings.baud_rate < 100.0_kHz) {
+    // The bus is sampled 3 times (recommended for low speeds, 100kHz is
+    // considered HIGH).
+    bus_timing.insert<bus_timing::sampling>(1);
+  } else {
+    bus_timing.insert<bus_timing::sampling>(0);
+  }
+
+  return success();
+}
+
+inline status can::setup(const can::port& p_port, settings p_settings) noexcept
 {
-  /// Power on CANBUS peripheral
-  internal::power(m_port.id).on();
+  /// Power on CAN BUS peripheral
+  power(p_port.id).on();
 
   /// Configure pins
-  m_port.td.function(m_port.td_function_code);
-  m_port.rd.function(m_port.rd_function_code);
+  p_port.td.function(p_port.td_function_code);
+  p_port.rd.function(p_port.rd_function_code);
 
   // Enable reset mode in order to write to CAN registers.
-  xstd::bitmanip(m_port.reg->MOD).set(mode::reset);
+  xstd::bitmanip(p_port.reg->MOD).set(mode::reset);
 
-  configure_baud_rate();
+  HAL_CHECK(configure_baud_rate(p_port, p_settings));
   enable_acceptance_filter();
 
-  xstd::bitmanip(m_port.reg->MOD).set(mode::self_test);
+  // Disable reset mode, enabling the device
+  xstd::bitmanip(p_port.reg->MOD).reset(mode::reset);
 
-  // Flip logic of enable such that, if enable = true, set reset mode to false
-  xstd::bitmanip(m_port.reg->MOD).reset(mode::reset);
-
-  return {};
+  return success();
 }
 
-inline status can::send(const message_t& p_message)
+inline status can::driver_configure(const settings& p_settings) noexcept
+{
+  return configure_baud_rate(m_port, p_settings);
+}
+
+inline status can::driver_send(const message_t& p_message) noexcept
 {
   lpc_message registers = message_to_registers(p_message);
 
@@ -476,45 +550,47 @@ inline status can::send(const message_t& p_message)
     }
   }
 
-  return {};
+  return success();
 }
 
-inline bool can::has_data()
+inline bool can::has_data() noexcept
 {
   return xstd::bitmanip(m_port.reg->GSR).test(global_status::receive_buffer);
 }
 
-inline status can::attach_interrupt(
-  std::function<void(const hal::can::message_t&)> p_receive_handler)
+inline status can::driver_on_receive(
+  std::function<can::handler> p_receive_handler) noexcept
 {
   if (p_receive_handler) {
     // Save the handler
     m_receive_handler = p_receive_handler;
     // Create a lambda that passes this object's reference to the stored handler
-    // TODO: this is completely broken and cannot work.
-    auto isr = [this]() { m_receive_handler(message_t{}); };
+    auto isr = [this]() {
+      auto message = receive();
+      m_receive_handler(message);
+    };
     auto handler = static_callable<can, 0, void(void)>(isr).get_handler();
-    cortex_m::interrupt(value(irq::can)).enable(handler);
+    HAL_CHECK(cortex_m::interrupt(value(irq::can)).enable(handler));
 
     xstd::bitmanip(m_port.reg->IER).set(interrupts::received_message);
   } else {
     // Disable CAN interrupt
     xstd::bitmanip(m_port.reg->IER).reset(interrupts::received_message);
     // Disable the Cortex-M interrupt
-    cortex_m::interrupt(value(irq::can)).disable();
+    HAL_CHECK(cortex_m::interrupt(value(irq::can)).disable());
   }
 
-  return {};
+  return success();
 }
 
-inline can::message_t can::receive()
+inline can::message_t can::receive() noexcept
 {
   message_t message;
 
   // Extract all of the information from the message frame
   auto frame = xstd::bitset(m_port.reg->RFS);
-  bool remote_request = frame.extract<frame_info::remote_request>().to_ulong();
-  uint32_t length = frame.extract<frame_info::length>().to_ulong();
+  auto remote_request = frame.test(frame_info::remote_request);
+  auto length = frame.extract<frame_info::length>().to<std::uint32_t>();
 
   message.is_remote_request = remote_request;
   message.length = static_cast<uint8_t>(length);
@@ -522,7 +598,7 @@ inline can::message_t can::receive()
   // Get the frame ID
   message.id = xstd::bitset(m_port.reg->RID)
                  .extract<xstd::bitrange::from<0, 28>()>()
-                 .to_ulong();
+                 .to<decltype(message.id)>();
 
   // Pull the bytes from RDA into the payload array
   message.payload[0] = (m_port.reg->RDA >> (0 * 8)) & 0xFF;
@@ -542,64 +618,11 @@ inline can::message_t can::receive()
   return message;
 }
 
-// TODO: this needs to return a bool if the baud rate cannot be achieved
-inline void can::configure_baud_rate()
-{
-  using namespace hal::literals;
-  // According to the BOSCH CAN spec, the nominal bit time is divided into 4
-  // time segments. These segments need to be programmed for the internal
-  // bit timing logic/state machine. Refer to the link below for more
-  // details about the importance of these time segments:
-  // http://www.keil.com/dd/docs/datashts/silabs/boschcan_ug.pdf
-  //
-  // Nominal Bit Time : 1 / 100 000 == 10^-5s
-  //
-  //   0________________________________10^-5
-  //  _/              1 bit             \_
-  //   \________________________________/
-  //
-  //   | SYNC  | PROP | PHASE1 | PHASE2 |    BOSCH
-  //   | T_SCL |    TSEG1      | TSEG2  |    LPC
-  //                           ^
-  //                           sample point (industry standard: 80%)
-  const auto sync_jump = m_port.sync_jump;
-  const auto tseg1 = m_port.tseg1;
-  const auto tseg2 = m_port.tseg2;
-  const auto clocks_per_bit = sync_jump + tseg1 + tseg2 + 3;
-  // The prescalar value defines the T_scl value, also known as the time quanta.
-  // Each CANBUS bit must equal `clocks_per_bit` number of time quanta. To make
-  // the clock_rate [per bit] into the time quanta, simply multiply the
-  // desired clock rate by the number of time quanta per bit.
-  // Then calculate the prescaler normally.
-  const auto clock_rate = settings().clock_rate * clocks_per_bit;
-  const auto frequency = internal::clock(m_port.id).get_frequency();
-  const uint32_t prescaler = (frequency / clock_rate) - 1;
-
-  // Hold the results in RAM rather than altering the register directly
-  // multiple times.
-  xstd::bitmanip bus_timing(m_port.reg->BTR);
-
-  // Used to compensate for positive and negative edge phase errors. Defines
-  // how much the sample point can be shifted.
-  // These time segments determine the location of the "sample point".
-  bus_timing.insert<bus_timing::sync_jump_width>(sync_jump)
-    .insert<bus_timing::time_segment1>(tseg1)
-    .insert<bus_timing::time_segment2>(tseg2)
-    .insert<bus_timing::prescalar>(prescaler);
-
-  if (settings().clock_rate < 100_kHz) {
-    // The bus is sampled 3 times (recommended for low speeds, 100kHz is
-    // considered HIGH).
-    bus_timing.insert<bus_timing::sampling>(1);
-  } else {
-    bus_timing.insert<bus_timing::sampling>(0);
-  }
-}
-
 /// Convert message into the registers LPC40xx can bus registers.
 ///
 /// @param message - message to convert.
-can::lpc_message can::message_to_registers(const message_t& message) const
+inline can::lpc_message can::message_to_registers(
+  const message_t& message) const
 {
   static constexpr auto highest_11_bit_number = 2048UL;
   lpc_message registers;
@@ -612,14 +635,14 @@ can::lpc_message can::message_to_registers(const message_t& message) const
         .insert<frame_info::length>(message.length)
         .insert<frame_info::remote_request>(message.is_remote_request)
         .insert<frame_info::format>(0)
-        .to_ulong();
+        .to<std::uint32_t>();
   } else {
     frame_info =
       xstd::bitset(0)
         .insert<frame_info::length>(message.length)
         .insert<frame_info::remote_request>(message.is_remote_request)
         .insert<frame_info::format>(1)
-        .to_ulong();
+        .to<std::uint32_t>();
   }
 
   uint32_t data_a = 0;
@@ -644,6 +667,6 @@ can::lpc_message can::message_to_registers(const message_t& message) const
 
 inline void can::enable_acceptance_filter()
 {
-  acceptance_filter->acceptance_filter = value(commands::accept_all_messages);
+  acceptance_filter().acceptance_filter = value(commands::accept_all_messages);
 }
 }  // namespace hal::lpc40xx

--- a/include/liblpc40xx/constants.hpp
+++ b/include/liblpc40xx/constants.hpp
@@ -130,4 +130,11 @@ enum class irq
   cmp1 = 42,
   max,
 };
+
+enum class error_t
+{
+  requires_usage_of_external_oscillator,
+  baud_rate_impossible,
+};
+
 }  // namespace hal::lpc40xx

--- a/include/liblpc40xx/incomplete_drivers/i2c.hpp.ignore
+++ b/include/liblpc40xx/incomplete_drivers/i2c.hpp.ignore
@@ -204,7 +204,7 @@ namespace hal::lpc40xx {
 inline status i2c::driver_configure(const settings& p_settings)
 {
   // Power on peripheral
-  internal::power(m_bus.peripheral_id).on();
+  power(m_bus.peripheral_id).on();
 
   // Setup pins for SDA and SCL
   internal::pin(m_bus.sda)
@@ -217,9 +217,9 @@ inline status i2c::driver_configure(const settings& p_settings)
     .resistor(pin_resistor::pull_up)
     .open_drain(true);
 
-  // Setup I2C operating freqency
+  // Setup I2C operating frequency
   const auto duty_cycle =
-    internal::clock()
+    clock()
       .get_frequency(m_bus.peripheral_id)
       .calculate_duty_cycle(p_settings.clock_rate, m_bus.duty_cycle);
   m_bus.reg->duty_cycle_low = duty_cycle.low;

--- a/include/liblpc40xx/internal/uart.hpp
+++ b/include/liblpc40xx/internal/uart.hpp
@@ -142,7 +142,7 @@ constexpr fractional_divider_t closest_fractional(int32_t p_ratio)
  * @brief Calculate the baud rate register values
  *
  * @param p_baud_rate - the target baud rate
- * @param p_frequency_hz - clock freqency driving uart peripheral
+ * @param p_frequency_hz - clock frequency driving uart peripheral
  * @return constexpr uart_baud_t - returns the baud rate register values
  */
 constexpr uart_baud_t calculate_baud(uint32_t p_baud_rate,

--- a/include/liblpc40xx/system_controller.hpp
+++ b/include/liblpc40xx/system_controller.hpp
@@ -9,7 +9,7 @@
 
 #include "constants.hpp"
 
-namespace hal::lpc40xx::internal {
+namespace hal::lpc40xx {
 /// lpc40xx system controller register map
 struct system_controller_t
 {
@@ -622,6 +622,8 @@ public:
     // Set spifi clock the source defined in the configuration
     xstd::bitmanip(system_controller_reg()->spifi_clock_select)
       .insert<spifi_clock::select>(static_cast<uint32_t>(m_config.spifi.clock));
+
+    return success();
   }
 
 private:
@@ -684,14 +686,15 @@ private:
     using namespace hal::literals;
 
     auto scs_register = xstd::bitmanip(system_controller_reg()->scs);
-    scs_register.set(oscillator::external_enable);
-
     auto frequency = m_config.oscillator_frequency;
+
     if (1.0_MHz <= frequency && frequency <= 20.0_MHz) {
       scs_register.reset(oscillator::range_select);
     } else if (20.0_MHz < frequency && frequency <= 25.0_MHz) {
       scs_register.set(oscillator::range_select);
     }
+
+    scs_register.set(oscillator::external_enable);
 
     // Commit the changes above to the register before checking the status bit.
     scs_register.save();
@@ -715,4 +718,4 @@ private:
   hertz m_spifi_clock_source_rate = irc_frequency;
   hertz m_peripheral_clock_rate = irc_frequency / default_peripheral_divider;
 };
-}  // namespace hal::lpc40xx::internal
+}  // namespace hal::lpc40xx

--- a/include/liblpc40xx/uart.hpp
+++ b/include/liblpc40xx/uart.hpp
@@ -327,7 +327,7 @@ inline status uart::driver_configure(const settings& p_settings) noexcept
 {
   // Validate the settings before configuring any hardware
   auto baud_rate = static_cast<std::uint32_t>(p_settings.baud_rate);
-  auto uart_frequency = internal::clock::get().get_frequency(m_port->id);
+  auto uart_frequency = clock::get().get_frequency(m_port->id);
   auto uart_frequency_hz = static_cast<std::uint32_t>(uart_frequency);
   auto baud_settings = internal::calculate_baud(baud_rate, uart_frequency_hz);
 
@@ -339,7 +339,7 @@ inline status uart::driver_configure(const settings& p_settings) noexcept
   }
 
   // Power on UART peripheral
-  internal::power(m_port->id).on();
+  power(m_port->id).on();
 
   // Enable fifo for receiving bytes and to enable full access of the FCR
   // register.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_C_COMPILER "gcc-11")
 set(CMAKE_CXX_COMPILER "g++-11")
 
-project(libhal_tests VERSION 0.0.1 LANGUAGES CXX)
+project(unit_test VERSION 0.0.1 LANGUAGES CXX)
 
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 set(CMAKE_BUILD_TYPE "Debug")
@@ -12,27 +12,25 @@ find_package(ut REQUIRED CONFIG)
 find_package(libarmcortex REQUIRED CONFIG)
 find_package(ring-span-lite REQUIRED CONFIG)
 
-set(TEST_NAME unit_test)
-set(CMAKE_BUILD_TYPE Debug)
-
-add_executable(${TEST_NAME}
+add_executable(${PROJECT_NAME}
   adc.test.cpp
   input_pin.test.cpp
   output_pin.test.cpp
   interrupt_pin.test.cpp
 
-  # can.test.cpp
-  # i2c.test.cpp
+  can.test.cpp
   uart.test.cpp
   main.test.cpp
+
+  # i2c.test.cpp
 )
 
-target_include_directories(${TEST_NAME} PUBLIC . ../include)
-target_compile_options(${TEST_NAME} PRIVATE -Werror -Wall -Wextra
+target_include_directories(${PROJECT_NAME} PUBLIC . ../include)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wextra
   -Wno-unused-function -Wconversion -Wno-psabi)
-target_compile_features(${TEST_NAME} PRIVATE cxx_std_20)
-set_target_properties(${TEST_NAME} PROPERTIES CXX_EXTENSIONS OFF)
-target_link_libraries(${TEST_NAME} PRIVATE
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE
   boost::ut
   libarmcortex::libarmcortex
   nonstd::ring-span-lite

--- a/tests/can.test.cpp
+++ b/tests/can.test.cpp
@@ -1,1 +1,13 @@
+#include <boost/ut.hpp>
 #include <liblpc40xx/can.hpp>
+
+namespace hal::lpc40xx {
+boost::ut::suite can_test = []() {
+  using namespace boost::ut;
+
+  [[maybe_unused]] auto& test_can = hal::lpc40xx::can::get<1>().value();
+
+  "can::ctor()"_test = []() {};
+  "can::configure()"_test = []() {};
+};
+}

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,5 +1,7 @@
 [requires]
 boost-ext-ut/1.1.8
+libhal/0.1.3
+libxbitset/[x]
 libarmcortex/[x]
 ring-span-lite/0.6.0
 


### PR DESCRIPTION
- Add hal::lpc40xx::can driver
- Add demos/can demonstration project
- Bump version to 0.2.1
- Add unit tests for can (this is incomplete and proves that the driver
  can be instantiated)

Resolves https://github.com/libhal/liblpc40xx/issues/12