### PR TITLE
Fix unset port in can::get() during tests

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibLPC40xxConan(ConanFile):
     name = "liblpc40xx"
-    version = "0.2.2"
+    version = "0.2.3"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/liblpc40xx"

--- a/include/liblpc40xx/can.hpp
+++ b/include/liblpc40xx/can.hpp
@@ -339,32 +339,32 @@ public:
 
     can::port port;
 
-    if constexpr (hal::is_platform("lpc40")) {
-      if constexpr (PortNumber == 1) {
-        port = can::port{
-          .td = internal::pin(0, 1),
-          .td_function_code = 1,
-          .rd = internal::pin(0, 0),
-          .rd_function_code = 1,
-          .reg = reinterpret_cast<can::reg_t*>(0x4004'4000),
-          .id = peripheral::can1,
-          .irq_number = irq::can,
-        };
-      } else if constexpr (PortNumber == 2) {
-        port = can::port{
-          .td = internal::pin(2, 8),
-          .td_function_code = 1,
-          .rd = internal::pin(2, 7),
-          .rd_function_code = 1,
-          .reg = reinterpret_cast<can::reg_t*>(0x4004'8000),
-          .id = peripheral::can2,
-          .irq_number = irq::can,
-        };
-      } else {
-        static_assert(hal::error::invalid_option<port>,
-                      "Support can ports for LPC40xx are can1 and can2.");
-      }
+    if constexpr (PortNumber == 1) {
+      port = can::port{
+        .td = internal::pin(0, 1),
+        .td_function_code = 1,
+        .rd = internal::pin(0, 0),
+        .rd_function_code = 1,
+        .reg = reinterpret_cast<can::reg_t*>(0x4004'4000),
+        .id = peripheral::can1,
+        .irq_number = irq::can,
+      };
+    } else if constexpr (PortNumber == 2) {
+      port = can::port{
+        .td = internal::pin(2, 8),
+        .td_function_code = 1,
+        .rd = internal::pin(2, 7),
+        .rd_function_code = 1,
+        .reg = reinterpret_cast<can::reg_t*>(0x4004'8000),
+        .id = peripheral::can2,
+        .irq_number = irq::can,
+      };
     } else {
+      static_assert(hal::error::invalid_option<port>,
+                    "Support can ports for LPC40xx are can1 and can2.");
+    }
+
+    if constexpr (hal::is_a_test()) {
       static std::array<can::reg_t, 2> registers{};
       port.reg = &registers[PortNumber - 1];
     }

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.8
-libhal/0.1.3
+libhal/[x]
 libxbitset/[x]
 libarmcortex/[x]
 ring-span-lite/0.6.0


### PR DESCRIPTION
- Bump version of libhal in tests to the latest
- Bump version of liblpc40xx