### PR TITLE
All ::get factories return result<T>

### DIFF
--- a/demos/applications/adc.cpp
+++ b/demos/applications/adc.cpp
@@ -11,8 +11,8 @@ hal::status application()
   hal::cortex_m::dwt_counter counter(
     hal::lpc40xx::clock::get().get_frequency(hal::lpc40xx::peripheral::cpu));
 
-  constexpr hal::serial::settings new_settings{ .baud_rate = 38400 };
-  auto& uart0 = hal::lpc40xx::uart::get<0>(new_settings);
+  constexpr hal::serial::settings uart_settings{ .baud_rate = 38400 };
+  auto& uart0 = HAL_CHECK(hal::lpc40xx::uart::get<0>(uart_settings));
   HAL_CHECK(hal::write(uart0, "ADC Application Starting...\n"));
   auto& adc4 = hal::lpc40xx::adc::get<4>().value();
   auto& adc2 = hal::lpc40xx::adc::get<2>().value();

--- a/demos/applications/blinker.cpp
+++ b/demos/applications/blinker.cpp
@@ -2,7 +2,6 @@
 #include <libarmcortex/dwt_counter.hpp>
 #include <libhal/serial/util.hpp>
 #include <libhal/steady_clock/util.hpp>
-#include <liblpc40xx/input_pin.hpp>
 #include <liblpc40xx/output_pin.hpp>
 #include <liblpc40xx/system_controller.hpp>
 #include <liblpc40xx/uart.hpp>
@@ -13,10 +12,12 @@ hal::status application()
   hal::cortex_m::dwt_counter steady_clock(
     clock.get_frequency(hal::lpc40xx::peripheral::cpu));
 
-  auto& uart0 = hal::lpc40xx::uart::get<0>({ .baud_rate = 38400.0f });
+  auto& uart0 = HAL_CHECK((hal::lpc40xx::uart::get<0>({
+    .baud_rate = 38400.0f,
+  })));
   HAL_CHECK(hal::write(uart0, "Starting blinker...\n"));
 
-  auto& led = hal::lpc40xx::output_pin::get<1, 18>();
+  auto& led = HAL_CHECK((hal::lpc40xx::output_pin::get<1, 18>()));
 
   while (true) {
     using namespace std::chrono_literals;

--- a/demos/applications/can.cpp
+++ b/demos/applications/can.cpp
@@ -24,7 +24,9 @@
   const auto cpu_frequency = clock.get_frequency(hal::lpc40xx::peripheral::cpu);
   hal::cortex_m::dwt_counter counter(cpu_frequency);
 
-  auto& uart0 = hal::lpc40xx::uart::get<0>({ .baud_rate = 38400.0f });
+  auto& uart0 = HAL_CHECK(hal::lpc40xx::uart::get<0>({
+    .baud_rate = 38400.0f,
+  }));
   auto& can1 = HAL_CHECK(
     hal::lpc40xx::can::get<1>(hal::can::settings{ .baud_rate = baudrate }));
   auto& can2 = HAL_CHECK(

--- a/demos/applications/gpio.cpp
+++ b/demos/applications/gpio.cpp
@@ -11,10 +11,12 @@ hal::status application()
   hal::cortex_m::dwt_counter clock(
     hal::lpc40xx::clock::get().get_frequency(hal::lpc40xx::peripheral::cpu));
 
-  auto& button = hal::lpc40xx::input_pin::get<0, 29>();
-  auto& led = hal::lpc40xx::output_pin::get<1, 18>();
+  auto& button = HAL_CHECK((hal::lpc40xx::input_pin::get<0, 29>()));
+  auto& led = HAL_CHECK((hal::lpc40xx::output_pin::get<1, 18>()));
 
   while (true) {
+    // Checking level for the lpc40xx drivers NEVER generates an error so this
+    // is fine.
     if (button.level().value()) {
       using namespace std::chrono_literals;
       HAL_CHECK(led.level(false));

--- a/demos/applications/interrupt_pin.cpp
+++ b/demos/applications/interrupt_pin.cpp
@@ -4,8 +4,9 @@
 
 hal::status application()
 {
-  auto& button = hal::lpc40xx::interrupt_pin::get<0, 29>();
-  auto& led = hal::lpc40xx::output_pin::get<1, 18>();
+  auto& button = HAL_CHECK((hal::lpc40xx::interrupt_pin::get<0, 29>()));
+  auto& led = HAL_CHECK((hal::lpc40xx::output_pin::get<1, 18>()));
+
   HAL_CHECK(led.level(false));
 
   HAL_CHECK(button.configure({}));

--- a/demos/applications/uart.cpp
+++ b/demos/applications/uart.cpp
@@ -19,7 +19,9 @@ hal::status application()
   const auto cpu_frequency = clock.get_frequency(hal::lpc40xx::peripheral::cpu);
   hal::cortex_m::dwt_counter counter(cpu_frequency);
 
-  auto& uart0 = hal::lpc40xx::uart::get<0>({ .baud_rate = 38400.0f });
+  auto& uart0 = HAL_CHECK(hal::lpc40xx::uart::get<0>({
+    .baud_rate = 38400.0f,
+  }));
 
   while (true) {
     using namespace std::chrono_literals;

--- a/include/liblpc40xx/can.hpp
+++ b/include/liblpc40xx/can.hpp
@@ -3,9 +3,9 @@
 #include <string_view>
 
 #include <libarmcortex/interrupt.hpp>
+#include <libhal/bit.hpp>
 #include <libhal/can/interface.hpp>
 #include <libhal/static_callable.hpp>
-#include <libxbitset/bitset.hpp>
 
 #include "constants.hpp"
 #include "internal/pin.hpp"
@@ -112,21 +112,21 @@ public:
   struct bus_timing
   {
     /// The peripheral bus clock is divided by this value
-    static constexpr auto prescalar = xstd::bitrange::from<0, 9>();
+    static constexpr auto prescalar = bit::mask::from<0, 9>();
 
     /// Used to compensate for positive and negative edge phase errors
-    static constexpr auto sync_jump_width = xstd::bitrange::from<14, 15>();
+    static constexpr auto sync_jump_width = bit::mask::from<14, 15>();
     /// The delay from the nominal Sync point to the sample point is (this value
     /// plus one) CAN clocks.
-    static constexpr auto time_segment1 = xstd::bitrange::from<16, 19>();
+    static constexpr auto time_segment1 = bit::mask::from<16, 19>();
 
     /// The delay from the sample point to the next nominal sync point isCAN
     /// clocks. The nominal CAN bit time is (this value plus the value in
     /// time_segment1 plus 3) CAN clocks.
-    static constexpr auto time_segment2 = xstd::bitrange::from<20, 22>();
+    static constexpr auto time_segment2 = bit::mask::from<20, 22>();
 
     /// How many times the bus is sampled; 0 == once, 1 == 3 times
-    static constexpr auto sampling = xstd::bitrange::from<23>();
+    static constexpr auto sampling = bit::mask::from<23>();
   };
 
   /// This struct holds interrupt flags and capture flag status. It is HW mapped
@@ -140,51 +140,51 @@ public:
     //       controller as soon as they are read.
 
     /// Assert interrupt when a new message has been received
-    static constexpr auto received_message = xstd::bitrange::from<0>();
+    static constexpr auto received_message = bit::mask::from<0>();
 
     /// Assert interrupt when TX Buffer 1 has finished or aborted its
     /// transmission.
-    static constexpr auto tx1_ready = xstd::bitrange::from<1>();
+    static constexpr auto tx1_ready = bit::mask::from<1>();
 
     /// Assert interrupt when bus status or error status is asserted.
-    static constexpr auto error_warning = xstd::bitrange::from<2>();
+    static constexpr auto error_warning = bit::mask::from<2>();
 
     /// Assert interrupt on data overrun occurs
-    static constexpr auto data_overrun = xstd::bitrange::from<3>();
+    static constexpr auto data_overrun = bit::mask::from<3>();
 
     /// Assert interrupt when CAN controller is sleeping and was woken up from
     /// bus activity.
-    static constexpr auto wakeup = xstd::bitrange::from<4>();
+    static constexpr auto wakeup = bit::mask::from<4>();
 
     /// Assert interrupt when the CAN Controller has reached the Error Passive
     /// Status (error counter exceeds 127)
-    static constexpr auto error_passive = xstd::bitrange::from<5>();
+    static constexpr auto error_passive = bit::mask::from<5>();
 
     /// Assert interrupt when arbitration is lost
-    static constexpr auto arbitration_lost = xstd::bitrange::from<6>();
+    static constexpr auto arbitration_lost = bit::mask::from<6>();
 
     /// Assert interrupt on bus error
-    static constexpr auto bus_error = xstd::bitrange::from<7>();
+    static constexpr auto bus_error = bit::mask::from<7>();
 
     /// Assert interrupt when any message has been successfully transmitted.
-    static constexpr auto identifier_ready = xstd::bitrange::from<8>();
+    static constexpr auto identifier_ready = bit::mask::from<8>();
 
     /// Assert interrupt when TX Buffer 2 has finished or aborted its
     /// transmission.
-    static constexpr auto tx2_ready = xstd::bitrange::from<9>();
+    static constexpr auto tx2_ready = bit::mask::from<9>();
 
     /// Assert interrupt when TX Buffer 3 has finished or aborted its
     /// transmission.
-    static constexpr auto tx3_ready = xstd::bitrange::from<10>();
+    static constexpr auto tx3_ready = bit::mask::from<10>();
 
     /// Error Code Capture status bits to be read during an interrupt
-    static constexpr auto error_code_location = xstd::bitrange::from<16, 20>();
+    static constexpr auto error_code_location = bit::mask::from<16, 20>();
     /// Indicates if the error occurred during transmission (0) or receiving (1)
-    static constexpr auto error_code_direction = xstd::bitrange::from<21>();
+    static constexpr auto error_code_direction = bit::mask::from<21>();
     /// The type of bus error that occurred such as bit error, stuff error, etc
-    static constexpr auto error_code_type = xstd::bitrange::from<22, 23>();
+    static constexpr auto error_code_type = bit::mask::from<22, 23>();
     /// Bit location of where arbitration was lost.
-    static constexpr auto arbitration_lost_loc = xstd::bitrange::from<24, 31>();
+    static constexpr auto arbitration_lost_loc = bit::mask::from<24, 31>();
   };
 
   /// This struct holds CAN controller global status information.
@@ -193,11 +193,11 @@ public:
   struct global_status
   {
     /// If 1, receive buffer has at least 1 complete message stored
-    static constexpr auto receive_buffer = xstd::bitrange::from<0>();
+    static constexpr auto receive_buffer = bit::mask::from<0>();
 
     /// Bus status bit. If this is '1' then the bus is active, otherwise the bus
     /// is bus off.
-    static constexpr auto bus_error = xstd::bitrange::from<7>();
+    static constexpr auto bus_error = bit::mask::from<7>();
   };
 
   /// This struct holds CAN controller status information. It is HW mapped to a
@@ -206,55 +206,55 @@ public:
   struct buffer_status
   {
     /// TX1 Buffer has been released
-    static constexpr auto tx1_released = xstd::bitrange::from<2>();
+    static constexpr auto tx1_released = bit::mask::from<2>();
 
     /// TX2 Buffer has been released
-    static constexpr auto tx2_released = xstd::bitrange::from<10>();
+    static constexpr auto tx2_released = bit::mask::from<10>();
 
     /// TX3 Buffer has been released
-    static constexpr auto tx3_released = xstd::bitrange::from<18>();
+    static constexpr auto tx3_released = bit::mask::from<18>();
   };
 
   /// CAN BUS modes
   struct mode
   {
     /// Reset CAN Controller, allows configuration registers to be modified.
-    static constexpr auto reset = xstd::bitrange::from<0>();
+    static constexpr auto reset = bit::mask::from<0>();
 
     /// Put device into Listen Only Mode, device will not acknowledge, messages.
-    static constexpr auto listen_only = xstd::bitrange::from<1>();
+    static constexpr auto listen_only = bit::mask::from<1>();
 
     /// Put device on self test mode.
-    static constexpr auto self_test = xstd::bitrange::from<2>();
+    static constexpr auto self_test = bit::mask::from<2>();
 
     /// Enable transmit priority control. When enabled, allows a particular
-    static constexpr auto tx_priority = xstd::bitrange::from<3>();
+    static constexpr auto tx_priority = bit::mask::from<3>();
 
     /// Put device to Sleep Mode.
-    static constexpr auto sleep_mode = xstd::bitrange::from<4>();
+    static constexpr auto sleep_mode = bit::mask::from<4>();
 
     /// Receive polarity mode. If 1 RD input is active high
-    static constexpr auto rx_polarity = xstd::bitrange::from<5>();
+    static constexpr auto rx_polarity = bit::mask::from<5>();
 
     /// Put CAN into test mode, which allows the TD pin to reflect its bits ot
     /// the RD pin.
-    static constexpr auto test = xstd::bitrange::from<7>();
+    static constexpr auto test = bit::mask::from<7>();
   };
 
   /// CAN Bus frame bit masks for the TFM and RFM registers
   struct frame_info
   {
     /// The message priority bits (not used in this implementation)
-    static constexpr auto priority = xstd::bitrange::from<0, 7>();
+    static constexpr auto priority = bit::mask::from<0, 7>();
 
     /// The length of the data
-    static constexpr auto length = xstd::bitrange::from<16, 19>();
+    static constexpr auto length = bit::mask::from<16, 19>();
 
     /// If set to 1, the message becomes a remote request message
-    static constexpr auto remote_request = xstd::bitrange::from<30>();
+    static constexpr auto remote_request = bit::mask::from<30>();
 
     /// If 0, the ID is 11-bits, if 1, the ID is 29-bits.
-    static constexpr auto format = xstd::bitrange::from<31>();
+    static constexpr auto format = bit::mask::from<31>();
   };
 
   /// https://www.nxp.com/docs/en/user-guide/UM10562.pdf (pg. 554)
@@ -411,7 +411,7 @@ public:
     // Disable generating an interrupt request by this CAN peripheral, but leave
     // the interrupt enabled. We must NOT disable the interrupt as it could be
     // used by the other CAN peripheral.
-    xstd::bitmanip(m_port.reg->IER).reset(interrupts::received_message);
+    bit::modify(m_port.reg->IER).clear<interrupts::received_message>();
   }
 
 private:
@@ -464,7 +464,7 @@ inline status can::configure_baud_rate(const can::port& p_port,
 
   // Hold the results in RAM rather than altering the register directly
   // multiple times.
-  xstd::bitmanip bus_timing(p_port.reg->BTR);
+  bit::modify bus_timing(p_port.reg->BTR);
 
   const auto sync_jump = p_settings.synchronization_jump_width - 1;
   const auto tseg1 =
@@ -503,13 +503,13 @@ inline status can::setup(const can::port& p_port, settings p_settings) noexcept
   p_port.rd.function(p_port.rd_function_code);
 
   // Enable reset mode in order to write to CAN registers.
-  xstd::bitmanip(p_port.reg->MOD).set(mode::reset);
+  bit::modify(p_port.reg->MOD).set(mode::reset);
 
   HAL_CHECK(configure_baud_rate(p_port, p_settings));
   enable_acceptance_filter();
 
   // Disable reset mode, enabling the device
-  xstd::bitmanip(p_port.reg->MOD).reset(mode::reset);
+  bit::modify(p_port.reg->MOD).clear(mode::reset);
 
   return success();
 }
@@ -527,23 +527,23 @@ inline status can::driver_send(const message_t& p_message) noexcept
   // through it.
   bool sent = false;
   while (!sent) {
-    const auto status_register = xstd::bitset(m_port.reg->SR);
+    const auto status_register = m_port.reg->SR;
     // Check if any buffer is available.
-    if (status_register.test(buffer_status::tx1_released)) {
+    if (bit::extract<buffer_status::tx1_released>(status_register)) {
       m_port.reg->TFI1 = registers.frame;
       m_port.reg->TID1 = registers.id;
       m_port.reg->TDA1 = registers.data_a;
       m_port.reg->TDB1 = registers.data_b;
       m_port.reg->CMR = value(commands::send_tx_buffer1);
       sent = true;
-    } else if (status_register.test(buffer_status::tx2_released)) {
+    } else if (bit::extract<buffer_status::tx2_released>(status_register)) {
       m_port.reg->TFI2 = registers.frame;
       m_port.reg->TID2 = registers.id;
       m_port.reg->TDA2 = registers.data_a;
       m_port.reg->TDB2 = registers.data_b;
       m_port.reg->CMR = value(commands::send_tx_buffer2);
       sent = true;
-    } else if (status_register.test(buffer_status::tx3_released)) {
+    } else if (bit::extract<buffer_status::tx3_released>(status_register)) {
       m_port.reg->TFI3 = registers.frame;
       m_port.reg->TID3 = registers.id;
       m_port.reg->TDA3 = registers.data_a;
@@ -558,7 +558,7 @@ inline status can::driver_send(const message_t& p_message) noexcept
 
 inline bool can::has_data() noexcept
 {
-  return xstd::bitmanip(m_port.reg->GSR).test(global_status::receive_buffer);
+  return bit::extract<global_status::receive_buffer>(m_port.reg->GSR);
 }
 
 inline status can::driver_on_receive(
@@ -575,10 +575,10 @@ inline status can::driver_on_receive(
     auto handler = static_callable<can, 0, void(void)>(isr).get_handler();
     HAL_CHECK(cortex_m::interrupt(value(irq::can)).enable(handler));
 
-    xstd::bitmanip(m_port.reg->IER).set(interrupts::received_message);
+    bit::modify(m_port.reg->IER).set(interrupts::received_message);
   } else {
     // Disable CAN interrupt
-    xstd::bitmanip(m_port.reg->IER).reset(interrupts::received_message);
+    bit::modify(m_port.reg->IER).clear(interrupts::received_message);
     // Disable the Cortex-M interrupt
     HAL_CHECK(cortex_m::interrupt(value(irq::can)).disable());
   }
@@ -588,20 +588,19 @@ inline status can::driver_on_receive(
 
 inline can::message_t can::receive() noexcept
 {
+  static constexpr auto id_mask = bit::mask::from<0, 28>();
   message_t message;
 
   // Extract all of the information from the message frame
-  auto frame = xstd::bitset(m_port.reg->RFS);
-  auto remote_request = frame.test(frame_info::remote_request);
-  auto length = frame.extract<frame_info::length>().to<std::uint32_t>();
+  auto frame = m_port.reg->RFS;
+  auto remote_request = bit::extract<frame_info::remote_request>(frame);
+  auto length = bit::extract<frame_info::length>(frame);
 
   message.is_remote_request = remote_request;
   message.length = static_cast<uint8_t>(length);
 
   // Get the frame ID
-  message.id = xstd::bitset(m_port.reg->RID)
-                 .extract<xstd::bitrange::from<0, 28>()>()
-                 .to<decltype(message.id)>();
+  message.id = bit::extract<id_mask>(m_port.reg->RID);
 
   // Pull the bytes from RDA into the payload array
   message.payload[0] = (m_port.reg->RDA >> (0 * 8)) & 0xFF;
@@ -634,14 +633,14 @@ inline can::lpc_message can::message_to_registers(
 
   if (message.id < highest_11_bit_number) {
     frame_info =
-      xstd::bitset(0)
+      bit::value<decltype(frame_info)>(0)
         .insert<frame_info::length>(message.length)
         .insert<frame_info::remote_request>(message.is_remote_request)
         .insert<frame_info::format>(0U)
         .to<std::uint32_t>();
   } else {
     frame_info =
-      xstd::bitset(0)
+      bit::value<decltype(frame_info)>(0)
         .insert<frame_info::length>(message.length)
         .insert<frame_info::remote_request>(message.is_remote_request)
         .insert<frame_info::format>(1U)

--- a/include/liblpc40xx/constants.hpp
+++ b/include/liblpc40xx/constants.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <cstdint>
+
 namespace hal::lpc40xx {
 /// List of each peripheral and their power on id number for this platform
-enum class peripheral
+enum class peripheral : std::uint8_t
 {
   lcd = 0,
   timer0 = 1,
@@ -40,94 +42,94 @@ enum class peripheral
 };
 
 /// List of interrupt request numbers for this platform
-enum class irq
+enum class irq : std::uint16_t
 {
   /// Watchdog Timer Interrupt
-  wdt = 0,
+  wdt = 16 + 0,
   /// Timer0 Interrupt
-  timer0 = 1,
+  timer0 = 16 + 1,
   /// Timer1 Interrupt
-  timer1 = 2,
+  timer1 = 16 + 2,
   /// Timer2 Interrupt
-  timer2 = 3,
+  timer2 = 16 + 3,
   /// Timer3 Interrupt
-  timer3 = 4,
+  timer3 = 16 + 4,
   /// UART0 Interrupt
-  uart0 = 5,
+  uart0 = 16 + 5,
   /// UART1 Interrupt
-  uart1 = 6,
+  uart1 = 16 + 6,
   /// UART2 Interrupt
-  uart2 = 7,
+  uart2 = 16 + 7,
   /// UART3 Interrupt
-  uart3 = 8,
+  uart3 = 16 + 8,
   /// PWM1 Interrupt
-  pwm1 = 9,
+  pwm1 = 16 + 9,
   /// I2C0 Interrupt
-  i2c0 = 10,
+  i2c0 = 16 + 10,
   /// I2C1 Interrupt
-  i2c1 = 11,
+  i2c1 = 16 + 11,
   /// I2C2 Interrupt
-  i2c2 = 12,
+  i2c2 = 16 + 12,
   /// Reserved
-  reserved0 = 13,
+  reserved0 = 16 + 13,
   /// SSP0 Interrupt
-  ssp0 = 14,
+  ssp0 = 16 + 14,
   /// SSP1 Interrupt
-  ssp1 = 15,
+  ssp1 = 16 + 15,
   /// PLL0 Lock (Main PLL) Interrupt
-  pll0 = 16,
+  pll0 = 16 + 16,
   /// Real Time Clock Interrupt
-  rtc = 17,
+  rtc = 16 + 17,
   /// External Interrupt 0 Interrupt
-  eint0 = 18,
+  eint0 = 16 + 18,
   /// External Interrupt 1 Interrupt
-  eint1 = 19,
+  eint1 = 16 + 19,
   /// External Interrupt 2 Interrupt
-  eint2 = 20,
+  eint2 = 16 + 20,
   /// External Interrupt 3 Interrupt
-  eint3 = 21,
+  eint3 = 16 + 21,
   /// A/D Converter Interrupt
-  adc = 22,
+  adc = 16 + 22,
   /// Brown-Out Detect Interrupt
-  bod = 23,
+  bod = 16 + 23,
   /// USB Interrupt
-  usb = 24,
+  usb = 16 + 24,
   /// CAN Interrupt
-  can = 25,
+  can = 16 + 25,
   /// General Purpose DMA Interrupt
-  dma = 26,
+  dma = 16 + 26,
   /// I2S Interrupt
-  i2s = 27,
+  i2s = 16 + 27,
   /// Ethernet Interrupt
-  enet = 28,
+  enet = 16 + 28,
   /// SD/MMC card I/F Interrupt
-  mci = 29,
+  mci = 16 + 29,
   /// Motor Control PWM Interrupt
-  mcpwm = 30,
+  mcpwm = 16 + 30,
   /// Quadrature Encoder Interface Interrupt
-  qei = 31,
+  qei = 16 + 31,
   /// PLL1 Lock (USB PLL) Interrupt
-  pll1 = 32,
+  pll1 = 16 + 32,
   /// USB Activity interrupt
-  usbactivity = 33,
+  usbactivity = 16 + 33,
   /// CAN Activity interrupt
-  canactivity = 34,
+  canactivity = 16 + 34,
   /// UART4 Interrupt
-  uart4 = 35,
+  uart4 = 16 + 35,
   /// SSP2 Interrupt
-  ssp2 = 36,
+  ssp2 = 16 + 36,
   /// LCD Interrupt
-  lcd = 37,
+  lcd = 16 + 37,
   /// GPIO Interrupt
-  gpio = 38,
+  gpio = 16 + 38,
   ///  PWM0 Interrupt
-  pwm0 = 39,
+  pwm0 = 16 + 39,
   ///  EEPROM Interrupt
-  eeprom = 40,
+  eeprom = 16 + 40,
   ///  CMP0 Interrupt
-  cmp0 = 41,
+  cmp0 = 16 + 41,
   ///  CMP1 Interrupt
-  cmp1 = 42,
+  cmp1 = 16 + 42,
   max,
 };
 ///

--- a/include/liblpc40xx/internal/gpio.hpp
+++ b/include/liblpc40xx/internal/gpio.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <libhal/bit.hpp>
 #include <libhal/config.hpp>
 
 #include "platform_check.hpp"
@@ -57,18 +58,23 @@ inline lpc_gpio_t* gpio_reg(size_t p_port)
  * @brief Check the bounds of a GPIO at compile time and generate a compiler
  * error if the pin and port combination are not supported.
  *
- * @tparam Port - selects pin port to use
- * @tparam Pin - selects pin within the port to use
+ * @tparam port - selects pin port to use
+ * @tparam pin - selects pin within the port to use
  */
-template<int Port, int Pin>
+template<std::uint8_t port, std::uint8_t pin>
 constexpr void check_gpio_bounds_at_compile()
 {
   compile_time_platform_check();
 
   static_assert(
-    (0 <= Port && Port <= 4 && 0 <= Pin && Pin <= 31) ||
-      (Port == 5 && 0 <= Pin && Pin < 4),
+    (0 <= port && port <= 4 && 0 <= pin && pin <= 31) ||
+      (port == 5 && 0 <= pin && pin < 4),
     "For ports between 0 and 4, the pin number must be between 0 and 31. For "
     "port 5, the pin number must be equal to or below 4");
+}
+
+constexpr bit::mask pin_mask(std::uint8_t p_pin)
+{
+  return bit::mask{ .position = p_pin, .width = 1 };
 }
 }  // namespace hal::lpc40xx::internal

--- a/include/liblpc40xx/internal/pin.hpp
+++ b/include/liblpc40xx/internal/pin.hpp
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 #include <cstring>
+#include <libhal/bit.hpp>
 #include <libhal/config.hpp>
 #include <libhal/input_pin/pin_resistors.hpp>
-#include <libxbitset/bitset.hpp>
 
 #include "gpio.hpp"
 
@@ -29,43 +29,43 @@ public:
 
   // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
   /// Bitmask for setting pin mux function code.
-  static constexpr auto range_function = xstd::bitrange::from<0, 2>();
+  static constexpr auto range_function = hal::bit::mask::from<0, 2>();
 
   /// Bitmask for setting resistor mode of pin.
-  static constexpr auto range_resistor = xstd::bitrange::from<3, 4>();
+  static constexpr auto range_resistor = hal::bit::mask::from<3, 4>();
 
   /// Bitmask for setting pin hysteresis mode.
-  static constexpr auto range_hysteresis = xstd::bitrange::from<5>();
+  static constexpr auto range_hysteresis = hal::bit::mask::from<5>();
 
   /// Bitmask for setting inputs as active low or active high. This will behave
   /// badly if the pin is set to a mode that is an output or set to analog. See
   /// usermanual for more details.
-  static constexpr auto range_input_invert = xstd::bitrange::from<6>();
+  static constexpr auto range_input_invert = hal::bit::mask::from<6>();
 
   /// Bitmask for setting a pin to analog mode.
-  static constexpr auto range_analog_digital_mode = xstd::bitrange::from<7>();
+  static constexpr auto range_analog_digital_mode = hal::bit::mask::from<7>();
 
   /// Bitmask for enabling/disabling digital filter. This can be used to
   /// ignore/reject noise, reflections, or signal bounce (from something like a
   /// switch).
-  static constexpr auto range_digital_filter = xstd::bitrange::from<8>();
+  static constexpr auto range_digital_filter = hal::bit::mask::from<8>();
 
   /// Bitmask to enable/disable high speed I2C mode
-  static constexpr auto range_i2c_highspeed = xstd::bitrange::from<8>();
+  static constexpr auto range_i2c_highspeed = hal::bit::mask::from<8>();
 
   /// Bitmask to change the slew rate of signal transitions for outputs for a
   /// pin.
-  static constexpr auto range_slew = xstd::bitrange::from<9>();
+  static constexpr auto range_slew = hal::bit::mask::from<9>();
 
   /// Bitmask to enable I2C high current drain. This can allow for even faster
   /// I2C communications, as well as allow for more devices on the bus.
-  static constexpr auto range_i2c_high_current = xstd::bitrange::from<9>();
+  static constexpr auto range_i2c_high_current = hal::bit::mask::from<9>();
 
   /// Bitmask to enable/disable open drain mode.
-  static constexpr auto range_open_drain = xstd::bitrange::from<10>();
+  static constexpr auto range_open_drain = hal::bit::mask::from<10>();
 
   /// Bitmask for enabling/disabling digital to analog pin mode.
-  static constexpr auto range_dac_enable = xstd::bitrange::from<16>();
+  static constexpr auto range_dac_enable = hal::bit::mask::from<16>();
 
   /// @return pin_map_t* -  Return the address of the pin map peripheral
   static pin_map_t* map()
@@ -103,7 +103,7 @@ public:
    */
   const pin& function(uint8_t p_function_code) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_function>(p_function_code);
     return *this;
   }
@@ -130,7 +130,7 @@ public:
     }
     // The pin resistor enumeration matches the values for the LPC40xx so simply
     // cast the enum to an int and this will work.
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_resistor>(resistor_code);
     return *this;
   }
@@ -143,7 +143,7 @@ public:
    */
   const pin& hysteresis(bool p_enable) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_hysteresis>(p_enable);
     return *this;
   }
@@ -156,7 +156,7 @@ public:
    */
   const pin& input_invert(bool p_enable) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_input_invert>(p_enable);
     return *this;
   }
@@ -170,7 +170,7 @@ public:
   const pin& analog(bool p_enable) const
   {
     bool is_digital = !p_enable;
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_analog_digital_mode>(is_digital);
     return *this;
   }
@@ -183,7 +183,7 @@ public:
    */
   const pin& digital_filter(bool p_enable) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_digital_filter>(p_enable);
     return *this;
   }
@@ -196,7 +196,7 @@ public:
    */
   const pin& highspeed_i2c(bool p_enable = true) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_i2c_highspeed>(p_enable);
     return *this;
   }
@@ -209,7 +209,7 @@ public:
    */
   const pin& high_slew_rate(bool p_enable = true) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin]).insert<range_slew>(p_enable);
+    hal::bit::modify(map()->matrix[m_port][m_pin]).insert<range_slew>(p_enable);
     return *this;
   }
 
@@ -221,7 +221,7 @@ public:
    */
   const pin& i2c_high_current(bool p_enable = true) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_i2c_high_current>(p_enable);
     return *this;
   }
@@ -234,7 +234,7 @@ public:
    */
   const pin& open_drain(bool p_enable = true) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_open_drain>(p_enable);
     return *this;
   }
@@ -247,7 +247,7 @@ public:
    */
   const pin& dac(bool p_enable = true) const
   {
-    xstd::bitmanip(map()->matrix[m_port][m_pin])
+    hal::bit::modify(map()->matrix[m_port][m_pin])
       .insert<range_dac_enable>(p_enable);
     return *this;
   }

--- a/include/liblpc40xx/interrupt_pin.hpp
+++ b/include/liblpc40xx/interrupt_pin.hpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 #include <libarmcortex/interrupt.hpp>
-#include <libhal/config.hpp>
 #include <libhal/enum.hpp>
 #include <libhal/interrupt_pin/interface.hpp>
 
@@ -78,9 +77,10 @@ public:
    */
   static void interrupt_handler()
   {
-    unsigned int triggered_port = reg()->status >> 2;
-    unsigned int triggered_pin = 0;
-    unsigned int status = 0;
+    std::uint32_t triggered_port = reg()->status >> 2;
+    std::uint32_t triggered_pin = 0;
+    bit::mask triggered_pin_mask;
+    std::uint32_t status = 0;
 
     if (triggered_port == 0) {
       // To keep the number of handler functions to a minimum, this library does
@@ -99,39 +99,43 @@ public:
     // interrupt is pin 5. If there are 0 zeros, then the first bit must be
     // set to a 1 and thus pin 0 is what set off this interrupt. And so on for
     // all other bits.
-    triggered_pin = static_cast<unsigned int>(std::countr_zero(status));
+    triggered_pin = static_cast<std::uint32_t>(std::countr_zero(status));
+    triggered_pin_mask = bit::mask::from(triggered_pin);
 
     if (triggered_port == 0) {
       // Clear interrupt flag on port 0. This is important as not doing this
       // will result in this interrupt being repeatedly called.
-      xstd::bitmanip(reg()->clear_interrupt_port0).set(triggered_pin);
+      bit::modify(reg()->clear_interrupt_port0).set(triggered_pin_mask);
     } else {
-      xstd::bitmanip(reg()->clear_interrupt_port2).set(triggered_pin);
+      bit::modify(reg()->clear_interrupt_port2).set(triggered_pin_mask);
     }
 
-    bool pin_level = xstd::bitmanip(internal::gpio_reg(triggered_port)->pin)
-                       .test(triggered_pin);
+    bool pin_level =
+      bit::extract(triggered_pin_mask, internal::gpio_reg(triggered_port)->pin);
+
     handlers[triggered_port][triggered_pin](pin_level);
   }
 
   /**
    * @brief Get the interrupt pin object
    *
-   * @tparam Port - selects pin port to use
-   * @tparam Pin - selects pin within the port to use
+   * @tparam port - selects pin port to use
+   * @tparam pin - selects pin within the port to use
    * @param p_settings - initial pin settings
    * @return interrupt_pin& - reference to a statically allocated interrupt pin
    */
-  template<std::uint8_t Port, std::uint8_t Pin>
-  static interrupt_pin& get(settings p_settings = {})
+  template<std::uint8_t port, std::uint8_t pin>
+  static result<interrupt_pin&> get(settings p_settings = {})
   {
     compile_time_platform_check();
 
-    static_assert(Port == 0 || Port == 2,
+    static_assert(port == 0 || port == 2,
                   "Interrupts are only supported for port 0 and 2.");
-    static_assert(0 <= Pin && Pin <= 31, "Pin can only be between 0 to 31.");
+    static_assert(0 <= pin && pin <= 31, "pin can only be between 0 to 31.");
 
-    static interrupt_pin gpio(Port, Pin, p_settings);
+    static interrupt_pin gpio(port, pin);
+    cortex_m::interrupt::initialize<value(irq::max)>();
+    HAL_CHECK(gpio.driver_configure(p_settings));
     return gpio;
   }
 
@@ -143,14 +147,10 @@ private:
    * @param p_pin - selects pin within the port to use
    * @param p_settings - initial pin settings
    */
-  interrupt_pin(std::uint8_t p_port,
-                std::uint8_t p_pin,
-                const settings& p_settings = {})
+  interrupt_pin(std::uint8_t p_port, std::uint8_t p_pin)
     : m_port(p_port)
     , m_pin(p_pin)
   {
-    cortex_m::interrupt::initialize<value(irq::max)>();
-    driver_configure(p_settings);
   }
 
   status driver_configure(const settings& p_settings) noexcept override;
@@ -164,7 +164,8 @@ inline status interrupt_pin::driver_configure(
   const settings& p_settings) noexcept
 {
   // Set pin as input
-  xstd::bitmanip(internal::gpio_reg(m_port)->direction).reset(m_pin);
+  bit::modify(internal::gpio_reg(m_port)->direction)
+    .clear(internal::pin_mask(m_pin));
 
   // Configure pin to use gpio function, use setting resistor and set the rest
   // to false.
@@ -181,18 +182,18 @@ inline status interrupt_pin::driver_configure(
   if (p_settings.trigger == trigger_edge::both ||
       p_settings.trigger == trigger_edge::rising) {
     if (m_port == 0) {
-      xstd::bitmanip(reg()->enable_raising_port0).set(m_pin);
+      bit::modify(reg()->enable_raising_port0).set(internal::pin_mask(m_pin));
     } else if (m_port == 2) {
-      xstd::bitmanip(reg()->enable_raising_port2).set(m_pin);
+      bit::modify(reg()->enable_raising_port2).set(internal::pin_mask(m_pin));
     }
   }
 
   if (p_settings.trigger == trigger_edge::both ||
       p_settings.trigger == trigger_edge::falling) {
     if (m_port == 0) {
-      xstd::bitmanip(reg()->enable_falling_port0).set(m_pin);
+      bit::modify(reg()->enable_falling_port0).set(internal::pin_mask(m_pin));
     } else if (m_port == 2) {
-      xstd::bitmanip(reg()->enable_falling_port2).set(m_pin);
+      bit::modify(reg()->enable_falling_port2).set(internal::pin_mask(m_pin));
     }
   }
 
@@ -205,11 +206,11 @@ inline void interrupt_pin::driver_on_trigger(
   // Disable interrupts if the callback is nullptr
   if (!p_callback) {
     if (m_port == 0) {
-      xstd::bitmanip(reg()->enable_raising_port0).reset(m_pin);
-      xstd::bitmanip(reg()->enable_falling_port0).reset(m_pin);
+      bit::modify(reg()->enable_raising_port0).clear(internal::pin_mask(m_pin));
+      bit::modify(reg()->enable_falling_port0).clear(internal::pin_mask(m_pin));
     } else if (m_port == 2) {
-      xstd::bitmanip(reg()->enable_raising_port2).reset(m_pin);
-      xstd::bitmanip(reg()->enable_falling_port2).reset(m_pin);
+      bit::modify(reg()->enable_raising_port2).clear(internal::pin_mask(m_pin));
+      bit::modify(reg()->enable_falling_port2).clear(internal::pin_mask(m_pin));
     }
   }
 

--- a/test_package/libhal.tweaks.hpp
+++ b/test_package/libhal.tweaks.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#define BOOST_LEAF_EMBEDDED
+#define BOOST_LEAF_NO_THREADS
+
 #include <string_view>
 
 namespace hal::config {

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,15 +1,12 @@
-#define BOOST_LEAF_EMBEDDED
-#define BOOST_LEAF_NO_THREADS
-
 #include <cstdio>
 #include <liblpc40xx/input_pin.hpp>
 
 int main()
 {
-  auto& input_pin = hal::lpc40xx::input_pin::get<2, 0>();
-  hal::result<bool> percentage = input_pin.level();
-  if (percentage) {
-    printf("Pin Level = %d\n", percentage.value());
+  auto& input_pin = hal::lpc40xx::input_pin::get<2, 0>().value();
+  hal::result<bool> pin_level = input_pin.level();
+  if (pin_level) {
+    printf("Pin Level = %d\n", pin_level.value());
   } else {
     printf("Reading pin level failed!\n");
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(${PROJECT_NAME}
   input_pin.test.cpp
   output_pin.test.cpp
   interrupt_pin.test.cpp
+  system_controller.test.cpp
 
   can.test.cpp
   uart.test.cpp

--- a/tests/system_controller.test.cpp
+++ b/tests/system_controller.test.cpp
@@ -1,0 +1,1 @@
+#include <liblpc40xx/system_controller.hpp>


### PR DESCRIPTION
- All factories now handle executing configure on the object rather than performing configuration in the constructor.
- Update demo applications to use correct result types
- Clean up some unneeded headers in various files
- Remove libxbitset and use hal::bit libraries
- Fix naming in test package
- Update irq numbers to reflect their unsigned event number rather than their signed version
- Add system_controller unit test file