### PR TITLE
:bug: Complete lpc40::i2c(i2c&&)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_lpc40_conan(ConanFile):
     name = "libhal-lpc40"
-    version = "2.1.5"
+    version = "2.1.6"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40"
@@ -124,5 +124,6 @@ class libhal_lpc40_conan(ConanFile):
 
         if self._bare_metal and self._use_linker_script:
             linker_path = os.path.join(self.package_folder, "linker_scripts")
-            link_script = "-Tlibhal-lpc40/" + str(self.options.platform) + ".ld"
+            link_script = "-Tlibhal-lpc40/" + \
+                str(self.options.platform) + ".ld"
             self.cpp_info.exelinkflags = ["-L" + linker_path, link_script]

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -36,7 +36,7 @@ class demos(ConanFile):
         self.tool_requires("libhal-cmake-util/3.0.1")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.1.5")
+        self.requires("libhal-lpc40/2.1.6")
 
     def build(self):
         cmake = CMake(self)

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -227,6 +227,14 @@ result<i2c> i2c::get(std::uint8_t p_bus_number, const i2c::settings& p_settings)
 }
 
 i2c::i2c(i2c&& p_other) noexcept
+  : m_bus(p_other.m_bus)
+  , m_write_iterator(p_other.m_write_iterator)
+  , m_write_end(p_other.m_write_end)
+  , m_read_iterator(p_other.m_read_iterator)
+  , m_read_end(p_other.m_read_end)
+  , m_status(p_other.m_status)
+  , m_address(p_other.m_address)
+  , m_busy(p_other.m_busy)
 {
   p_other.m_moved = true;
   setup_interrupt();
@@ -234,6 +242,16 @@ i2c::i2c(i2c&& p_other) noexcept
 
 i2c& i2c::operator=(i2c&& p_other) noexcept
 {
+  m_bus = p_other.m_bus;
+  m_write_iterator = p_other.m_write_iterator;
+  m_write_end = p_other.m_write_end;
+  m_read_iterator = p_other.m_read_iterator;
+  m_read_end = p_other.m_read_end;
+  m_status = p_other.m_status;
+  m_address = p_other.m_address;
+  m_busy = p_other.m_busy;
+  m_moved = false;
+
   p_other.m_moved = true;
   setup_interrupt();
   return *this;


### PR DESCRIPTION
- Move constructor was missing the assignment of all of its members.
- :bookmark: Bump version to 2.1.6